### PR TITLE
feat:supabase keepaliveを追加

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,19 @@
+name: Supabase Keepalive
+
+on:
+  schedule:
+    - cron: '0 3 */3 * *'
+  workflow_dispatch:
+
+jobs:
+  prod-keepalive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Call production keepalive endpoint
+        env:
+          PROD_KEEP_ALIVE_SECRET: ${{ secrets.PROD_KEEP_ALIVE_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            --header "Authorization: Bearer ${PROD_KEEP_ALIVE_SECRET}" \
+            "https://movie-review-nine-zeta.vercel.app/api/internal/keepalive"

--- a/src/app/api/internal/keepalive/route.ts
+++ b/src/app/api/internal/keepalive/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/utils/api/db'
+
+const keepAliveSecret = process.env.KEEP_ALIVE_SECRET
+
+function isAuthorized(request: NextRequest) {
+  if (!keepAliveSecret) {
+    throw new Error('KEEP_ALIVE_SECRET is not defined')
+  }
+
+  const authorizationHeader = request.headers.get('authorization')
+  const bearerToken = authorizationHeader?.startsWith('Bearer ')
+    ? authorizationHeader.slice('Bearer '.length)
+    : null
+  const cronSecret = request.headers.get('x-cron-secret')
+
+  return bearerToken === keepAliveSecret || cronSecret === keepAliveSecret
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    if (!isAuthorized(request)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 401,
+            message: 'Unauthorized',
+          },
+        },
+        { status: 401 },
+      )
+    }
+
+    await prisma.$queryRaw`SELECT 1`
+
+    return NextResponse.json({
+      ok: true,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('keepalive failed:', error)
+
+    return NextResponse.json(
+      {
+        error: {
+          code: 500,
+          message: 'Internal Server Error',
+        },
+      },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
This pull request introduces a keepalive mechanism to ensure the application's production environment remains responsive. It adds a scheduled GitHub Actions workflow and a secure internal API endpoint to perform periodic health checks by pinging the application and verifying database connectivity.

**Keepalive workflow automation:**

* [`.github/workflows/keepalive.yml`](diffhunk://#diff-5b612017aa186f5db53b7d1e0e0c902905179baa378516b2391fc91965fd89a7R1-R19): Adds a scheduled GitHub Actions workflow that triggers every three days at 3:00 AM UTC, calling the production keepalive endpoint with a secret for authorization.

**Internal keepalive endpoint:**

* `src/app/api/internal/keepalive/route.ts`: Implements a new internal API route that:
  - Checks for a valid authorization token in the request headers.
  - Performs a simple database query to verify connectivity.
  - Returns a timestamped JSON response on success or appropriate error messages on failure.