### PR TITLE
fix:supabase keepaliveの実行証跡を追加

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -14,6 +14,6 @@ jobs:
         env:
           PROD_KEEP_ALIVE_SECRET: ${{ secrets.PROD_KEEP_ALIVE_SECRET }}
         run: |
-          curl --fail --show-error --silent \
+          curl --fail --show-error \
             --header "Authorization: Bearer ${PROD_KEEP_ALIVE_SECRET}" \
             "https://movie-review-nine-zeta.vercel.app/api/internal/keepalive"

--- a/src/app/api/internal/keepalive/route.ts
+++ b/src/app/api/internal/keepalive/route.ts
@@ -31,11 +31,28 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    await prisma.$queryRaw`SELECT 1`
+    const checkedAt = new Date().toISOString()
+    const user = await prisma.user.findFirst({
+      select: {
+        id: true,
+      },
+      orderBy: {
+        id: 'asc',
+      },
+    })
+
+    console.log('KEEPALIVE_DB_OK', {
+      checkedAt,
+      hasUser: user !== null,
+    })
 
     return NextResponse.json({
       ok: true,
-      timestamp: new Date().toISOString(),
+      db: {
+        checked: true,
+        hasUser: user !== null,
+      },
+      timestamp: checkedAt,
     })
   } catch (error) {
     console.error('keepalive failed:', error)


### PR DESCRIPTION
## 概要

このプルリクエストでは、Supabase keepalive の実行結果を GitHub Actions と Vercel Logs の両方から確認しやすくします。

これまでの `SELECT 1` では実行証跡が追いにくかったため、Prisma 経由で実テーブルを参照し、DB 到達の成功ログとレスポンス本文を残すように変更しています。

## 変更内容

### Keepalive API

- `SELECT 1` ではなく `User` テーブルへの `findFirst` を実行し、Prisma 経由で実DBに到達していることを確認できるようにしました（`src/app/api/internal/keepalive/route.ts`）。
- 成功時に `KEEPALIVE_DB_OK` ログを出力し、実行時刻とユーザー有無を Vercel Logs で確認できるようにしました（`src/app/api/internal/keepalive/route.ts`）。
- API レスポンスに `db.checked` と `db.hasUser` を含め、GitHub Actions の実行ログからも DB チェック結果を見られるようにしました（`src/app/api/internal/keepalive/route.ts`）。

### GitHub Actions

- `curl --silent` を外し、keepalive API のレスポンス本文が Actions のログに出力されるようにしました（`.github/workflows/keepalive.yml`）。

## 期待される効果

これらの変更により、keepalive のスケジュール実行が Vercel API に到達しただけでなく、Prisma 経由で Supabase DB まで到達したことを確認しやすくなります。
